### PR TITLE
Fix build with override map

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "easy-error",
  "epub-builder",
  "hex",
+ "lazy_static",
  "regex",
  "reqwest",
  "select",

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use easy_error::{ResultExt, Error, err_msg};
 
 lazy_static! {
     static ref NEXT_LINK_OVERRIDES: HashMap<String, Url> = HashMap::from([
-        ("Hard Pass - 22.4", "https://palewebserial.wordpress.com/2022/12/27/hard-pass-22-5/"),
+        ("Hard Pass – 22.4", "https://palewebserial.wordpress.com/2022/12/27/hard-pass-22-5/"),
     ].map(|(title, url)| (title.to_string(), Url::parse(url).unwrap())));
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,10 +22,9 @@ use std::io::Write;
 use easy_error::{ResultExt, Error, err_msg};
 
 lazy_static! {
-    static ref OVERRIDE: HashMap<&'static str, &'static str> = {
-        let mut map = HashMap::new();
-        map.insert("Hard Pass - 22.4", "https://palewebserial.wordpress.com/2022/12/27/hard-pass-22-5/");
-    }
+    static ref NEXT_LINK_OVERRIDES: HashMap<String, Url> = HashMap::from([
+        ("Hard Pass - 22.4", "https://palewebserial.wordpress.com/2022/12/27/hard-pass-22-5/"),
+    ].map(|(title, url)| (title.to_string(), Url::parse(url).unwrap())));
 }
 
 struct Book {
@@ -402,9 +401,7 @@ fn download_pages(
         } else {
             link = None
         }
-        if let Some(url_str) = OVERRIDE.get(title) {
-            link = Some(Url::parse(url_str)?);
-        }
+        link = NEXT_LINK_OVERRIDES.get(&title).cloned().or(link);
         chapter_number += 1
     }
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,9 @@ use easy_error::{ResultExt, Error, err_msg};
 lazy_static! {
     static ref NEXT_LINK_OVERRIDES: HashMap<String, Url> = HashMap::from([
         ("Hard Pass – 22.4", "https://palewebserial.wordpress.com/2022/12/27/hard-pass-22-5/"),
+        ("Hard Pass – 22.6", "https://palewebserial.wordpress.com/2023/01/10/hard-pass-22-7/"),
+        ("Hard Pass – 22.7", "https://palewebserial.wordpress.com/2023/01/14/hard-pass-22-z/"),
+        ("Hard Pass – 22.z", "https://palewebserial.wordpress.com/2023/01/21/go-for-the-throat-23-1/"),
     ].map(|(title, url)| (title.to_string(), Url::parse(url).unwrap())));
 }
 


### PR DESCRIPTION
The `OVERRIDE` definition was missing a semicolon and the value block was missing `map` as the return value. And the `Url::parse()` was lacking `.context()` call, not creating a proper `EasyError`. And `HashMap.get()` wants a key that can be borrowed so I converted the keys to `String`.

While at it, let’s also define the HashMap more declaratively, including the use of final types.
