### PR TITLE
made it clear how to get seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Automatically scrapes wildbow's web serials and compiles them into ebooks
 - Ward
 - Pale
 - Claw
+- Seek
 
 ## Installation
 
@@ -41,6 +42,7 @@ FLAGS:
     -h, --help         Prints help information
     -p, --pact         Scrape Pact?
     -l, --pale         Scrape Pale?
+    -s, --seek         Scrape Seek?
     -t, --twig         Scrape Twig?
     -V, --version      Prints version information
     -r, --ward         Scrape Ward?

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Automatically scrapes wildbow's web serials and compiles them into ebooks
 
 ## Installation
 
-You'll need [cargo](https://github.com/rust-lang/cargo) installed. Run:
+You'll need [rust](https://www.rust-lang.org/tools/install) installed. Run:
 
 `git clone https://github.com/nicohman/rust-wildbow-scraper.git && cd rust-wildbow-scraper`
 


### PR DESCRIPTION
issue #63 shows it isn't clear how to install seek because I forgot to include seek in the readme

also changed cargo dependency to rust as we don't want people installing cargo by itself